### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/darcy-framework/synq.png?label=ready&title=Ready)](https://waffle.io/darcy-framework/synq)
 synq
 ====
 [![Build Status](https://travis-ci.org/darcy-framework/synq.svg?branch=master)](https://travis-ci.org/darcy-framework/synq) [![Coverage Status](https://coveralls.io/repos/darcy-framework/synq/badge.png?branch=master)](https://coveralls.io/r/darcy-framework/synq?branch=master)


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/darcy-framework/synq

This was requested by a real person (user alechenninger) on waffle.io, we're not trying to spam you.
